### PR TITLE
Add configurable relay polarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ DEVICE_FAN=18
 DEVICE_PUMP=27
 DEVICE_HEATER=22
 
+# Relay logic
+# Set to "true" if the relay activates on HIGH.
+# Set to "false" for active-low relays.
+RELAY_ON_HIGH=true
+
 # Default timeout in seconds (optional, for timed operations)
 DEFAULT_TIMEOUT=3600
 

--- a/env.sample
+++ b/env.sample
@@ -18,6 +18,11 @@ DEVICE_FAN=18
 DEVICE_PUMP=27
 DEVICE_HEATER=22
 
+# Relay logic
+# Set to "true" if the relay turns ON when the pin is HIGH.
+# Set to "false" for active-low relays that turn ON when the pin is LOW.
+RELAY_ON_HIGH=true
+
 # Default timeout in minutes (optional, for timed operations)
 DEFAULT_TIMEOUT=60
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -241,3 +241,14 @@ class TestScheduleConfiguration:
 
                     # Should not create any schedules due to invalid formats
                     assert "pump" not in DEVICE_SCHEDULES
+
+    def test_relay_on_high_env_var(self):
+        """Ensure RELAY_ON_HIGH is parsed from environment variables."""
+        with patch.dict(os.environ, {"RELAY_ON_HIGH": "false"}):
+            import importlib
+            from waterbot import config as config_module
+
+            importlib.reload(config_module)
+
+            assert config_module.RELAY_ON_HIGH is False
+        importlib.reload(config_module)

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,6 +1,7 @@
 """Test cases for WaterBot Discord integration."""
 
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
+import subprocess
 
 import pytest
 
@@ -31,6 +32,14 @@ class TestWaterBot:
         assert self.bot.channel_id == 123456789
         assert self.bot.target_channel is None
 
+    def test_get_ip_addresses(self):
+        """Test _get_ip_addresses parses output correctly."""
+        mock_ls = subprocess.CompletedProcess(["ls"], 0, stdout="eth0 lo\n")
+        mock_ip = subprocess.CompletedProcess(["ip"], 0, stdout="    inet 10.0.0.2/24\n")
+        with patch("subprocess.run", side_effect=[mock_ls, mock_ip]):
+            result = self.bot._get_ip_addresses()
+        assert result == {"eth0": "10.0.0.2"}
+
     @pytest.mark.asyncio
     async def test_on_ready(self):
         """Test on_ready event."""
@@ -45,7 +54,8 @@ class TestWaterBot:
 
         with patch.object(type(self.bot), "user", new_callable=PropertyMock) as mock_user_prop:
             mock_user_prop.return_value = mock_user
-            await self.bot.on_ready()
+            with patch.object(self.bot, "_get_ip_addresses", return_value={}):
+                await self.bot.on_ready()
 
         assert self.bot.target_channel == mock_channel
         mock_channel.send.assert_called_once()

--- a/tests/test_gpio_handler.py
+++ b/tests/test_gpio_handler.py
@@ -127,6 +127,20 @@ class TestDeviceController:
             # Check that GPIO cleanup was called
             assert self.mock_gpio.cleanup_called is True
 
+    @patch("waterbot.gpio.handler.RELAY_ON_HIGH", False)
+    def test_active_low_logic(self):
+        """Ensure controller handles active-low relay configuration."""
+        mock_gpio = MockGPIO()
+        controller = DeviceController(mock_gpio)
+
+        # Initial setup should set pins to HIGH (off state)
+        assert (17, True) in mock_gpio.output_calls
+
+        controller.turn_on("pump")
+        assert (17, False) in mock_gpio.output_calls
+        controller.turn_off("pump")
+        assert mock_gpio.output_calls[-1] == (17, True)
+
 
 class TestDeviceControllerModuleFunctions:
     """Test module-level functions."""

--- a/waterbot/config.py
+++ b/waterbot/config.py
@@ -22,6 +22,11 @@ OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 OPERATION_MODE = os.getenv("OPERATION_MODE", "emulation").lower()
 IS_EMULATION = OPERATION_MODE != "rpi"
 
+# Relay activation configuration
+# Some relay modules are active-low, meaning the device turns on when the
+# GPIO pin is set to LOW. Set RELAY_ON_HIGH to ``false`` in those cases.
+RELAY_ON_HIGH = os.getenv("RELAY_ON_HIGH", "true").lower() == "true"
+
 # Default timeout (in minutes)
 DEFAULT_TIMEOUT = int(os.getenv("DEFAULT_TIMEOUT", "60"))
 

--- a/waterbot/gpio/handler.py
+++ b/waterbot/gpio/handler.py
@@ -4,7 +4,7 @@ import logging
 from threading import Lock, Timer
 from typing import Dict, Optional
 
-from ..config import DEVICE_TO_PIN, IS_EMULATION
+from ..config import DEVICE_TO_PIN, IS_EMULATION, RELAY_ON_HIGH
 from .interface import EmulationGPIO, GPIOInterface, HardwareGPIO  # noqa: I100
 
 logger = logging.getLogger("gpio_handler")
@@ -48,17 +48,18 @@ class DeviceController:
 
     def _setup_devices(self) -> None:
         """Set up all configured devices."""
+        off_state = not RELAY_ON_HIGH
         for device, pin in DEVICE_TO_PIN.items():
             if self.gpio is not None:
                 self.gpio.setup(pin, "OUT")
-                self.gpio.output(pin, False)
+                self.gpio.output(pin, off_state)
             self.device_status[device] = False
             self.device_timers[device] = None
 
         logger.info(f"Setup {len(DEVICE_TO_PIN)} devices")
 
     def turn_on(self, device: str, timeout: Optional[int] = None) -> bool:
-        """Turn on a device by setting GPIO pin HIGH (for low-activated relays).
+        """Turn on a device by setting the GPIO pin to the active level.
 
         Args:
             device: Name of the device to turn on
@@ -78,10 +79,11 @@ class DeviceController:
                 timer.cancel()
                 self.device_timers[device] = None
 
-            # Turn on the device (set pin HIGH for low-activated relays)
+            # Turn on the device using configured relay logic
             pin = DEVICE_TO_PIN[device]
+            on_state = RELAY_ON_HIGH
             if self.gpio is not None:
-                self.gpio.output(pin, True)  # HIGH = ON
+                self.gpio.output(pin, on_state)
             self.device_status[device] = True
 
             if IS_EMULATION:
@@ -99,7 +101,7 @@ class DeviceController:
         return True
 
     def turn_off(self, device: str, timeout: Optional[int] = None) -> bool:
-        """Turn off a device by setting GPIO pin LOW (for low-activated relays).
+        """Turn off a device by setting the GPIO pin to the inactive level.
 
         Args:
             device: Name of the device to turn off
@@ -119,10 +121,11 @@ class DeviceController:
                 timer.cancel()
                 self.device_timers[device] = None
 
-            # Turn off the device (set pin LOW for low-activated relays)
+            # Turn off the device using configured relay logic
             pin = DEVICE_TO_PIN[device]
+            off_state = not RELAY_ON_HIGH
             if self.gpio is not None:
-                self.gpio.output(pin, False)  # LOW = OFF
+                self.gpio.output(pin, off_state)
             self.device_status[device] = False
 
             if IS_EMULATION:


### PR DESCRIPTION
## Summary
- support active-low relay modules with new `RELAY_ON_HIGH` option
- update GPIO handler to respect the configurable on/off polarity
- document new option in README and env.sample
- cover new behaviour in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fe5c0c0c4832a98b0596036f2582b